### PR TITLE
tests: add .travis.yml for travis-ci integration and allow OMCACHE_AGAIN from stats call

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+compiler: gcc
+install: make get-deps
+
+script: make && make check check-valgrind
+
+env:
+  - WITHOUT_ASYNCNS=1
+  - WITHOUT_ASYNCNS=

--- a/Makefile
+++ b/Makefile
@@ -99,3 +99,6 @@ check-coverity:
 
 check-pylint:
 	pylint --rcfile pylintrc *.py
+
+get-deps:
+	sudo apt-get install libasyncns-dev check memcached valgrind

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
-OMcache
+OMcache |BuildStatus|_
 =======
+
+.. |BuildStatus| image:: https://travis-ci.org/saaros/omcache.png?branch=master
+.. _BuildStatus: https://travis-ci.org/saaros/omcache
 
 OMcache is a C and Python library for accessing memcached servers.  The
 goals of the OMcache project are a stable API and ABI and 'easy' integration


### PR DESCRIPTION
For resolving issue #9 add .travis.yml to run tests automatically using travis. This still needs to be done by signing in to travis and enabling travis for project saaros/omcache (steps 1 and 2: http://docs.travis-ci.com/user/getting-started/). I tried this in my own fork and it seems to work ok: https://travis-ci.org/peekeri/omcache.
