### PR TITLE
omcache: Make compilation work on OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ INCLUDEDIR ?= $(PREFIX)/include
 
 STLIB_A = libomcache.a
 SHLIB_SO = libomcache.so
+SHLIB_DYLIB = libomcache.dylib
 SHLIB_V = $(SHLIB_SO).0
+SHLIB_DYLIB_V = $(SHLIB_DYLIB).0
+
 OBJ = omcache.o commands.o dist.o md5.o util.o
 CPPFLAGS ?= -Wall -Wextra
 CFLAGS ?= -g -O2
@@ -18,6 +21,8 @@ WITH_LIBS += -lasyncns
 endif
 
 all: $(SHLIB_SO) $(STLIB_A)
+
+osx: $(SHLIB_DYLIB)
 
 $(STLIB_A): $(OBJ)
 	ar rc $@ $^
@@ -30,6 +35,12 @@ $(SHLIB_V): $(OBJ) symbol.map
 	$(CC) $(LDFLAGS) -shared -fPIC \
 		-Wl,-soname=$(SHLIB_V) -Wl,-version-script=symbol.map \
 		$(filter-out symbol.map,$^) -o $@ -lrt $(WITH_LIBS)
+
+$(SHLIB_DYLIB): $(SHLIB_DYLIB_V)
+	ln -fs $(SHLIB_DYLIB_V) $(SHLIB_DYLIB)
+
+$(SHLIB_DYLIB_V): $(OBJ)
+	$(CC) *.c -dynamiclib $(LDFLAGS) -o $@
 
 %.o: %.c
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(WITH_CFLAGS) -D_GNU_SOURCE=1 -std=gnu99 -fPIC -c $^
@@ -60,7 +71,7 @@ deb:
 	dpkg-buildpackage -uc -us
 
 clean:
-	$(RM) $(STLIB_A) $(SHLIB_V) $(SHLIB_SO) $(OBJ)
+	$(RM) $(STLIB_A) $(SHLIB_V) $(SHLIB_SO) $(SHLIB_DYLIB_V) $(SHLIB_DYLIB) $(OBJ)
 	$(MAKE) -C tests clean
 
 check:

--- a/commands.c
+++ b/commands.c
@@ -9,7 +9,12 @@
  *
  */
 
+#if defined( __APPLE__)
+#include "port-osx.h"
+#else
 #include <endian.h>
+#endif
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/omcache.c
+++ b/omcache.c
@@ -10,7 +10,13 @@
  */
 
 #include <ctype.h>
+
+#if defined( __APPLE__)
+#include "port-osx.h"
+#else
 #include <endian.h>
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>

--- a/omcache.py
+++ b/omcache.py
@@ -27,7 +27,10 @@ _ffi.cdef("""
     };
     """)
 _ffi.cdef(open(os.path.join(os.path.dirname(__file__), "omcache_cdef.h")).read())
-_oc = _ffi.dlopen("libomcache.so.0")
+try:
+    _oc = _ffi.dlopen("libomcache.so.0")
+except:
+    _oc = _ffi.dlopen("libomcache.dylib.0")
 
 DELTA_NO_ADD = 0xffffffff
 

--- a/port-osx.h
+++ b/port-osx.h
@@ -1,0 +1,40 @@
+/*
+ * port-osx.h - required definitions and functions for OS X
+ *
+ * Copyright (c) 2013-2014, Hannu Valtonen <hannu.valtonen@ohmu.fi>
+ * All rights reserved.
+ *
+ * This file is under the Apache License, Version 2.0.
+ * See the file `LICENSE` for details.
+ *
+ */
+
+#include <libkern/OSByteOrder.h>
+#include <machine/endian.h>
+#include <string.h>
+#include <sys/time.h>
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL SO_NOSIGPIPE
+#endif
+
+#define CLOCK_MONOTONIC 2
+
+static int clock_gettime(int clk_id __attribute__((unused)), struct timespec* t) {
+    struct timeval tv;
+    int rv = gettimeofday(&tv, NULL);
+    if (rv)
+        return rv;
+    t->tv_sec  = tv.tv_sec;
+    t->tv_nsec = tv.tv_usec * 1000;
+    return 0;
+}
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)


### PR DESCRIPTION
OS X lacks some Linux specific functionality. Define required OSX
equivalents and add an OSX Makefile build target.

In the Python CFFI wrapper, if unable to load the .so file try to
load the .dylib instead.
